### PR TITLE
first pass fix for artifact 1.0

### DIFF
--- a/design/requirements.toml
+++ b/design/requirements.toml
@@ -135,7 +135,8 @@ text = '''
 
 '''
 
-[TST-flox-variables]
+[TST-flox]
+[TST-flox-variable]
 text = '''
 Variables
 '''
@@ -145,6 +146,8 @@ text = '''
 This test demonstrates the successful extraction of variable names from a flox
 string.
 '''
+
+[TST-serialization]
 
 [TST-serialization-fs]
 text = '''
@@ -161,6 +164,7 @@ text = '''
 Model serialization tests demonstrating the serialization to and deserialization from YAML
 '''
 
+[TST-xflow]
 [TST-xflow-call]
 text = '''
 Tests that have xflows invoking other xflows and using the result.

--- a/src/structure/common.rs
+++ b/src/structure/common.rs
@@ -350,7 +350,7 @@ impl DocumentHeader {
 
     /// Return a YAML representation of the DocumentHeader
     ///
-    /// partof: #SPC-serialization-yaml
+    /// partof: SPC-serialization-yaml
     pub fn to_yaml(&self) -> String {
         serde_yaml::to_string(&self).unwrap()
     }

--- a/tests/test_structure_model.rs
+++ b/tests/test_structure_model.rs
@@ -7,7 +7,7 @@ use gears::structure::model::*;
 #[test]
 fn test_load_model() {
     let _ = env_logger::init();
-    // #TST-serialization
+    // TST-serialization
     // #TST-serialization-yaml
     // partof: TST-serialization-fs
     // partof: TST-serialization-json

--- a/tests/test_xflow.rs
+++ b/tests/test_xflow.rs
@@ -4,7 +4,7 @@ extern crate gears;
 use gears::structure::xflow::*;
 
 // partof: #TST-xflow
-// partof: #TST-serialization
+// partof: TST-serialization
 
 #[test]
 fn test_xflow_default() {


### PR DESCRIPTION
This is a first pass fix of documentation for artifact 1.0 (to be released shortly) . Note there is still a couple failing checks:

```
$ art check                                                                                                                                                                        
                                                                                                                                                                                                                  
Found implementation links in the code that do not exist:
- src/flox.rs:
- [60] SPC-flox-variable-extraction
- tests/flox_test.rs:
  - [358] TST-flox-variable-error-reporting
- tests/test_generation_xflow_to_es5.rs:
  - [13] TST-artifact-generation-xflow
```

Also, I recommend [exporting your design docs to a github page](https://github.com/vitiral/artifact/blob/master/docs/ExportingHtml.md).

Be sure to use `--path-url` as well! And thanks for using artifact!